### PR TITLE
Destructor of scope_success can throw

### DIFF
--- a/include/nonstd/scope.hpp
+++ b/include/nonstd/scope.hpp
@@ -827,7 +827,9 @@ public:
         other.release();
     }
 
-    scope_constexpr_ext ~scope_success() scope_noexcept
+    scope_constexpr_ext ~scope_success() scope_noexcept_op(
+        scope_noexcept_op(exit_function())
+    )
     {
         if ( uncaught_on_creation >= detail::uncaught_exceptions() )
             exit_function();

--- a/test/scope.t.cpp
+++ b/test/scope.t.cpp
@@ -327,6 +327,27 @@ CASE( "scope_success: exit function is not called when released" )
     EXPECT_NOT( is_called );
 }
 
+CASE( "scope_success: exit function can throw (lambda)" )
+{
+#if scope_USE_POST_CPP98_VERSION
+    is_called = false;
+
+    try
+    {
+        {
+            //skipped_guard is expected to not be called, as the destructor of guard will throw.
+            auto skipped_guard = make_scope_success( [](){ is_called = false; } );
+            auto guard = make_scope_success( [](){ is_called = true; throw 0; } );
+        }
+    }
+    catch(...) {}
+
+    EXPECT( is_called );
+#else
+    EXPECT( !!"lambda is not available (no C++11)" );
+#endif
+}
+
 // resource type to test unique_resource:
 
 struct Resource


### PR DESCRIPTION
Hi Martin,
I hope you are fine with me creating this PR. According to the specs, the destructor of `scope_success` can throw.