### PR TITLE
Fix Clang builds on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [11, 12]
+        include:
+          - version: 11
+            os: 'ubuntu-22.04'
+          - version: 12
+            os: 'ubuntu-22.04'
+          - version: 19
+            os: 'ubuntu-24.04'
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
A while ago the `ubuntu-latest` image moved from Ubuntu 22.04 to Ubuntu 24.04. See <https://github.com/actions/runner-images/issues/10636>. However, Ubuntu 24.04 does not have packages for Clang 11 and 12 anymore, thus the Clang jobs fail when they try to install the corresponding compilers. Therefore, the workflow is changed to use `ubuntu-22.04` instead of `ubuntu-latest`.

Furthermore, a job for Clang 19 (latest Clang version available on Ubuntu 24.04) is added to run tests with a newer version, too.

_(This is basically the same pull request as <https://github.com/martinmoene/expected-lite/pull/79> or <https://github.com/martinmoene/variant-lite/pull/52>, but for scope-lite.)_